### PR TITLE
Modernize packaging and update dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ The pyreadline package is a python implementation of GNU readline functionality
 it is based on the ctypes based UNC readline package by Gary Bishop. 
 It is not complete. It has been tested for use with windows 2000 and windows xp.
 
-Version 2.0 runs on Python 2.6, 2.7, and >3.2 using the same code.
+Version 2.2 requires Python 3.9 or later.
 
 Features:
  *  keyboard text selection and copy/paste

--- a/eggsetup.py
+++ b/eggsetup.py
@@ -29,5 +29,8 @@ setup(name=name,
       data_files       = [('doc', glob.glob("doc/*")),
                          ],
       zip_safe         = False,
+      install_requires = ['pywin32>=311'],
+      extras_require   = {'docs': ['sphinx>=8.2.3']},
+      python_requires  = '>=3.9',
       )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,11 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=2.7,<4.0"
-pywin32 = "^308"
+python = ">=3.9,<4.0"
+pywin32 = ">=311"
 
 [tool.poetry.dev-dependencies]
-sphinx = "^5.0" 
+sphinx = ">=8.2.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 import os
 import sys
 import glob
-from distutils.core import setup
+from setuptools import setup
 from platform import system
 
 _S = system()
@@ -55,6 +55,9 @@ setup(name=name,
       packages         = packages,
       package_data     = {'pyreadline':['configuration/*']},
       data_files       = [],
-      cmdclass = cmd_class
+      cmdclass         = cmd_class,
+      install_requires = ['pywin32>=311'],
+      extras_require   = {'docs': ['sphinx>=8.2.3']},
+      python_requires  = '>=3.9'
       )
 


### PR DESCRIPTION
## Summary
- Require Python 3.9+ and update pywin32 and Sphinx to current releases
- Modernize setup scripts to declare dependencies and Python support
- Document new Python version requirement

## Testing
- `python -m pytest` *(fails: pyreadline is for Windows only, not Linux)*
- `python -m unittest` *(fails: pyreadline is for Windows only, not Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68a59780858c83268f6e4c25a9597b65