### PR TITLE
Pin Sphinx per Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,12 @@ python = ">=2.7,<4.0"
 pywin32 = "^308"
 
 [tool.poetry.dev-dependencies]
-# Sphinx 8.2 adds support for upcoming Python 3.13 releases
-sphinx = ">=8.2.3"
+# Pin Sphinx per supported Python version
+sphinx = [
+    {version = "==7.4.7", python = "<3.10"},
+    {version = "==8.1.3", python = ">=3.10,<3.11"},
+    {version = ">=8.2.3,<9", python = ">=3.11"},
+]
 tomli = {version = "^2.0", python = "<3.11"}
 
 [build-system]


### PR DESCRIPTION
## Summary
- restrict Sphinx dev dependency to versions supported by each Python release

## Testing
- `poetry check`
- `pytest` *(fails: RuntimeError: pyreadline is for Windows only)*

------
https://chatgpt.com/codex/tasks/task_e_68a5abe418308326957961bdf2b571d9