### PR TITLE
fix poetry warnings by adopting PEP 621 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,40 +1,42 @@
-[tool.poetry]
-name = "pyreadline"
-version = "2.2.1"
-description = "A python implementation of GNU readline functionality, based on the ctypes-based UNC readline package by Gary Bishop"
-homepage = "https://ipython.org/pyreadline"
-repository = "https://github.com/djstompzone/pyreadline"
-authors = [
-    "Jörgen Stenarson <jorgen.stenarson@bostream.nu>",
-    "Gary Bishop <gb@cs.unc.edu>",
-    "Jack Trainor <unknown@unknown.com>",
-    "Takayuki Shimizukawa <shimizukawa@gmail.com>",
-    "DJ Magar <admin@stomp.zone>",
-]
-maintainers = [
-     "DJ Magar <admin@stomp.zone>",
-     "Jörgen Stenarson <jorgen.stenarson@bostream.nu>"
-]
-license = "BSD-3-Clause"
-readme = ["README.rst", "doc/README.txt"]
-classifiers = [
-    "Development Status :: 6 - Mature",
-    "Environment :: Console",
-    "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Terminals",
-    "Topic :: Utilities"
-]
+ [project]
+ name = "pyreadline"
+ version = "2.2.1"
+ description = "A python implementation of GNU readline functionality, based on the ctypes-based UNC readline package by Gary Bishop"
+ readme = "README.rst"
+ requires-python = ">=2.7,<4.0"
+ license = {text = "BSD-3-Clause"}
+ authors = [
+     {name = "Jörgen Stenarson", email = "jorgen.stenarson@bostream.nu"},
+     {name = "Gary Bishop", email = "gb@cs.unc.edu"},
+     {name = "Jack Trainor"},
+     {name = "Takayuki Shimizukawa", email = "shimizukawa@gmail.com"},
+     {name = "DJ Magar", email = "admin@stomp.zone"},
+ ]
+ maintainers = [
+     {name = "DJ Magar", email = "admin@stomp.zone"},
+     {name = "Jörgen Stenarson", email = "jorgen.stenarson@bostream.nu"}
+ ]
+ classifiers = [
+     "Development Status :: 6 - Mature",
+     "Environment :: Console",
+     "Operating System :: Microsoft :: Windows",
+     "Programming Language :: Python :: Implementation :: CPython",
+     "Topic :: Software Development :: Libraries :: Python Modules",
+     "Topic :: Terminals",
+     "Topic :: Utilities"
+ ]
+ dependencies = [
+     "pywin32>=308,<309",
+ ]
 
-[tool.poetry.dependencies]
-python = ">=2.7,<4.0"
-pywin32 = "^308"
+ [project.urls]
+ Homepage = "https://ipython.org/pyreadline"
+ Repository = "https://github.com/djstompzone/pyreadline"
 
-[tool.poetry.dev-dependencies]
-# Sphinx 8.2 adds support for upcoming Python 3.13 releases
-sphinx = ">=8.2.3"
-tomli = {version = "^2.0", python = "<3.11"}
+ [tool.poetry.group.dev.dependencies]
+ # Sphinx 8.2 adds support for upcoming Python 3.13 releases
+ sphinx = ">=8.2.3"
+ tomli = {version = "^2.0", python = "<3.11"}
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@
      "Topic :: Utilities"
  ]
  dependencies = [
-     "pywin32>=308,<309",
+     "pywin32^308",
  ]
 
  [project.urls]


### PR DESCRIPTION
## Summary
- adopt PEP 621 `[project]` metadata and project URLs
- move dev dependencies under `[tool.poetry.group.dev]`
- simplify README declaration to one rst file

## Testing
- `poetry check`
- `pytest` *(fails: pyreadline is for Windows only)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ad043d3883268dcb1ad84a3cd67a