### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - name: Run tests
+      run: |
+        python -m pytest


### PR DESCRIPTION
## Summary
- run tests on Windows using GitHub Actions
- test across Python 3.8 through 3.12

## Testing
- `python -m pytest` *(fails: pyreadline is for Windows only, not Linux.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b1d2943c83268352bd53b3cc55fd

## Summary by Sourcery

CI:
- Add GitHub Actions build workflow to run pytest on Windows with a python-version matrix from 3.8 to 3.12